### PR TITLE
remove modprobe zswap

### DIFF
--- a/post-install.sh
+++ b/post-install.sh
@@ -56,7 +56,6 @@ sudo fallocate -l 16G /swapfile
 sudo chmod 600 /swapfile
 sudo mkswap /swapfile
 sudo swapon /swapfile
-sudo modprobe zswap
 
 ## añadir al /etc/fstab, verificar /dev/nvme1n1pX
 ROOT_UUID=$(blkid -s UUID -o value /dev/nvme1n1p3)


### PR DESCRIPTION
`modprobe zswap`, no es necesario siempre que se meta en le grub `zswap.enabled=1`, se puede verificar su estado con `cat /sys/module/zswap/parameters/enabled` si devuelve `Y` zswap está activado y funcionando